### PR TITLE
Improve navbar visibility & some tweaks

### DIFF
--- a/themes/liquid-glass.theme.css
+++ b/themes/liquid-glass.theme.css
@@ -381,8 +381,8 @@ html body {
     padding: 0 5px !important;
 }
 
-/* Selected tab look */
-#app [class*="nav-tab-button-container"].selected {
+/* Tabs look */
+#app [class*="nav-tab-button-container"] {
     background: rgba(70, 70, 70, 0.22) !important;
     border-radius: 999px !important;
     box-shadow:
@@ -1071,7 +1071,7 @@ body.ghost-clicking #heroLoadingScreen {
         inset 0 1px 0 rgba(255, 255, 255, 0.15),
         inset 0 -1px 0 rgba(0, 0, 0, 0.1) !important;
     backdrop-filter: var(--backdrop-filter) !important;
-    border: 1px solid rgba(255, 255, 255, 0.04) !important;
+    border: 2px solid rgba(255, 255, 255, 0.5) !important;
     opacity: 1 !important;
     transform: translateY(0px) scale(1) !important;
 }
@@ -1576,10 +1576,17 @@ body.ghost-clicking #heroLoadingScreen {
 .chip-L3r9A.active-jnhyP {
     background: rgba(70, 70, 70, 0.22) !important;
     box-shadow:
-        0 8px 32px rgba(0, 0, 0, 0.2),
-        0 4px 16px rgba(0, 0, 0, 0.1),
-        inset 0 1px 0 rgba(255, 255, 255, 0.15),
-        inset 0 -1px 0 rgba(0, 0, 0, 0.1) !important;
+        0 2px 8px rgba(0, 0, 0, 0.2),
+        inset 0 1px 0 rgba(255, 255, 255, 0.15) !important;
+    backdrop-filter: var(--backdrop-filter) !important;
+    border: 1px solid rgba(255, 255, 255, 0.04) !important;
+}
+
+.menu-xeE06 .button-DNmYL.selected-S7SeK {
+    background: rgba(70, 70, 70, 0.22) !important;
+    box-shadow:
+        0 4px 12px rgba(0, 0, 0, 0.3),
+        inset 0 1px 0 rgba(255, 255, 255, 0.25) !important;
     backdrop-filter: var(--backdrop-filter) !important;
     border: 1px solid rgba(255, 255, 255, 0.04) !important;
 }
@@ -1760,12 +1767,8 @@ body.ghost-clicking #heroLoadingScreen {
 }
 
 .cell-l3eWl.today-G8kuO .heading-TYXvp .day-nttmc {
-    background: rgba(70, 70, 70, 0.22) !important;
-    box-shadow:
-        0 2px 8px rgba(0, 0, 0, 0.2),
-        inset 0 1px 0 rgba(255, 255, 255, 0.08) !important;
-    backdrop-filter: var(--backdrop-filter) !important;
-    border: 1px solid rgba(255, 255, 255, 0.2) !important;
+    color: rgb(20, 20, 20) !important;
+    background: var(--bg-color) !important;
 }
 
 .shortcut-container-iOrn9 kbd {

--- a/themes/liquid-glass.theme.css
+++ b/themes/liquid-glass.theme.css
@@ -570,7 +570,7 @@ html body {
 }
 
 .meta-item-container-Tj0Ib .poster-container-qkw48 .new-videos-cwuD9 {
-    z-index: 1;
+    z-index: 50;
 }
 
 .meta-item-container-Tj0Ib .poster-container-qkw48 .new-videos-cwuD9 .layer-dQmEe .icon-gh1t9 {
@@ -1647,6 +1647,11 @@ body.ghost-clicking #heroLoadingScreen {
     pointer-events: none !important; /* let clicks pass through if needed */
     opacity: 1 !important;
     transition: opacity 0.25s ease !important;
+}
+
+.library-container-zM_bj .meta-item-container-Tj0Ib .poster-container-qkw48 .watched-icon-layer-bi3DO {
+    background: radial-gradient(ellipse at center, rgba(0,0,0,0.3) 0%, rgba(0,0,0,0.5) 100%) !important; 
+    backdrop-filter: none !important;
 }
 
 /* Hide any existing inner icons/svg so only our pseudo-elements show */

--- a/themes/liquid-glass.theme.css
+++ b/themes/liquid-glass.theme.css
@@ -569,6 +569,10 @@ html body {
     visibility: hidden;
 }
 
+.meta-item-container-Tj0Ib .poster-container-qkw48 .new-videos-cwuD9 {
+    z-index: 1;
+}
+
 .meta-item-container-Tj0Ib .poster-container-qkw48 .new-videos-cwuD9 .layer-dQmEe .icon-gh1t9 {
     color: rgb(157, 157, 157);
 }

--- a/themes/liquid-glass.theme.css
+++ b/themes/liquid-glass.theme.css
@@ -19,7 +19,7 @@
     --primary-accent-color: #fff;
     --background: rgb(20, 20, 20);
 
-    --bg-color: rgb(250, 251, 255, 0.74);
+    --bg-color: rgba(250, 251, 255, 0.74);
     --bg-color-img: linear-gradient(45deg, #f4f4fc, #f4f4fc);
     --bg-progress-color: #0c0c0c;
     --bg-hover-color: rgba(12, 12, 12, 0.05);
@@ -1650,7 +1650,7 @@ body.ghost-clicking #heroLoadingScreen {
 }
 
 .library-container-zM_bj .meta-item-container-Tj0Ib .poster-container-qkw48 .watched-icon-layer-bi3DO {
-    background: radial-gradient(ellipse at center, rgba(0,0,0,0.3) 0%, rgba(0,0,0,0.5) 100%) !important; 
+    background: radial-gradient(ellipse at center, rgba(0,0,0,0.3) 0%, rgba(0,0,0,0.5) 100%) !important;
     backdrop-filter: none !important;
 }
 
@@ -1777,7 +1777,7 @@ body.ghost-clicking #heroLoadingScreen {
 
 .cell-l3eWl.today-G8kuO .heading-TYXvp .day-nttmc {
     color: rgb(20, 20, 20) !important;
-    background: var(--bg-color) !important;
+    background: var(--or) !important;
 }
 
 .shortcut-container-iOrn9 kbd {


### PR DESCRIPTION
This PR improves the navbar visibility as suggested in #20 by making all tabs blurry and giving the selected tab a border:

<img width="924" height="266" alt="Screenshot_20260123_04h24m05" src="https://github.com/user-attachments/assets/995127ff-534b-40c4-a6d4-6b1e0ae58e36" /><br>

I also improved the box shadow for the selected tab in the library, added glass styling to the selected tab in the settings and improved visibility for the current day in the calendar.
