### PR TITLE
fix: remove conflicting opacity on player menu layer

### DIFF
--- a/themes/liquid-glass.theme.css
+++ b/themes/liquid-glass.theme.css
@@ -471,7 +471,6 @@ html body {
         inset 0 -1px 0 rgba(0, 0, 0, 0.1) !important;
     backdrop-filter: var(--backdrop-filter) !important;
     border: 1px solid rgba(255, 255, 255, 0.04) !important;
-    opacity: 1 !important;
 }
 
 .next-video-popup-container-H4wnL .button-container-i4F7t.play-button-Dluk6 {


### PR DESCRIPTION
Removed the 'opacity: 1 !important' line in '.player-container-wIELK .layer-qalDW.menu-layer-HZFG9' which was causing Stremio's modals (e.g. network statistics) to not close correctly because it conflicted with the opacity transition applied by Stremio.