### PR TITLE
Follow-up to #34: bring its still-ahead plugins up to date on v26 (no regressions)

### DIFF
--- a/plugins/data-enrichment.plugin.js
+++ b/plugins/data-enrichment.plugin.js
@@ -1,12 +1,13 @@
-(() => {
-    // Prevent multiple injections from Stremio's Mod Manager
-    if (window.__DataEnrichmentLoaded) return;
-    window.__DataEnrichmentLoaded = true;
+function waitForElement(selector, timeout = 10000) {
+    return new Promise((resolve, reject) => {
+        const element = document.querySelector(selector);
+        if (element) return resolve(element);
 
-    function waitForElement(selector, timeout = 10000) {
-        return new Promise((resolve, reject) => {
-            const element = document.querySelector(selector);
-            if (element) return resolve(element);
+        const startObservation = () => {
+            if (!document.body) {
+                setTimeout(startObservation, 50);
+                return;
+            }
 
             const observer = new MutationObserver(() => {
                 const el = document.querySelector(selector);
@@ -16,308 +17,692 @@
                 }
             });
             
-            const target = document.body || document.documentElement;
-            observer.observe(target, { childList: true, subtree: true });
+            observer.observe(document.body, { childList: true, subtree: true });
 
             setTimeout(() => {
                 observer.disconnect();
                 reject(new Error(`Timeout: ${selector}`));
             }, timeout);
+        };
+        
+        startObservation();
+    });
+}
+
+/**
+ * @name Data Enrichment
+ * @description Enriches movie and TV show details with TMDB data including enhanced cast, similar titles, collections, and ratings.
+ * @version 2.0.8
+ * @author MrBlu03
+ * @credits Inspired by the Stremio Neo project
+ */
+
+class DataEnrichment {
+    constructor() {
+        this.config = this.loadConfig();
+        this.cache = new Map();
+        this.observer = null;
+        this.settingsObserver = null;
+        this.hashChangeHandler = null;
+        this.currentImdbId = null;
+        this.currentUrl = null;  // Track URL to detect navigation
+        this.currentTmdbId = null;  // Track TMDB ID for StremThru catalogs
+        this.lastEnrichmentTime = 0;
+        this.isEnriching = false;
+        this.enrichmentTimeout = null;
+        this.checkDebounceTimer = null;
+        this.periodicCheckInterval = null;
+        this.reactCheckTimer = null;
+        this.init();
+    }
+
+    loadConfig() {
+        const saved = localStorage.getItem('dataEnrichmentConfig');
+        const defaults = {
+            tmdbApiKey: '',
+            enhancedCast: true,
+            description: true,
+            maturityRating: true,
+            similarTitles: true,
+            showCollection: true,
+            showRatingsOnPosters: true
+        };
+        return saved ? { ...defaults, ...JSON.parse(saved) } : defaults;
+    }
+
+    saveConfig() {
+        localStorage.setItem('dataEnrichmentConfig', JSON.stringify(this.config));
+    }
+
+    init() {
+        console.log('[DataEnrichment] Plugin loaded successfully v2.0.8');
+        
+        // Wait for body to be ready before setting up observers
+        if (!document.body) {
+            console.log('[DataEnrichment] Waiting for document.body...');
+            const checkBody = () => {
+                if (document.body) {
+                    this.setupObservers();
+                } else {
+                    setTimeout(checkBody, 50);
+                }
+            };
+            checkBody();
+            return;
+        }
+        
+        this.setupObservers();
+    }
+    
+    setupObservers() {
+        this.setupObserver();
+        this.setupHashChangeListener();
+        this.injectSettingsButton();
+        
+        // Initial check - wait for React to finish initial render
+        this.waitForReactRender(() => {
+            this.checkForDetailPage();
+            this.checkForPosters();
         });
     }
 
-    /**
-     * @name Data Enrichment
-     * @description Enriches movie and TV show details with TMDB data including enhanced cast, similar titles, collections, and ratings.
-     * @version 1.0.0
-     * @author MrBlu03
-     * @credits Inspired by the Stremio Neo project
-     */
-
-    class DataEnrichment {
-        constructor() {
-            this.config = this.loadConfig();
-            this.cache = new Map();
-            this.observer = null;
-            this.currentImdbId = null;
-            this.lastEnrichmentTime = 0; // Track when we last created content
-            this.isEnriching = false; // Flag to prevent re-entrancy
-            this.checkDebounceTimer = null;
-            this.init();
-        }
-
-        loadConfig() {
-            const saved = localStorage.getItem('dataEnrichmentConfig');
-            const defaults = {
-                tmdbApiKey: '',
-                rpdbApiKey: '', 
-                enhancedCast: true,
-                description: true,
-                maturityRating: true,
-                similarTitles: true,
-                showCollection: true,
-                showRatingsOnPosters: true
-            };
-            return saved ? { ...defaults, ...JSON.parse(saved) } : defaults;
-        }
-
-        saveConfig() {
-            localStorage.setItem('dataEnrichmentConfig', JSON.stringify(this.config));
-        }
-
-        init() {
-            console.log('[DataEnrichment] Plugin loaded successfully v1.0.0');
-            this.setupObserver();
-            this.setupHashChangeListener();
-            this.injectSettingsButton();
-            
-            waitForElement('.meta-details-container').then(() => {
-                 this.checkForDetailPage();
-            }).catch(() => {
-                 setTimeout(() => this.checkForDetailPage(), 1000);
+    // Wait for React to finish rendering (paint phase)
+    waitForReactRender(callback, maxAttempts = 30) {
+        let attempts = 0;
+        
+        const check = () => {
+            requestAnimationFrame(() => {
+                attempts++;
+                
+                // Check if detail content actually exists
+                const hasDetailContent = this.verifyContentLoaded(false);
+                
+                if (hasDetailContent) {
+                    console.log('[DataEnrichment] React content detected after', attempts, 'attempts');
+                    callback();
+                } else if (attempts < maxAttempts) {
+                    // Keep checking
+                    setTimeout(check, 100);
+                } else {
+                    // Max attempts reached, try anyway
+                    console.log('[DataEnrichment] Max attempts reached, proceeding anyway');
+                    callback();
+                }
             });
+        };
+        
+        check();
+    }
+
+    // Verify that content is actually loaded (not just empty containers)
+    verifyContentLoaded(logDetails = true) {
+        // Check for multiple indicators that content is actually loaded
+        const indicators = {
+            hasDescription: !!document.querySelector('[class*="description"]'),
+            hasTitle: !!document.querySelector('[class*="logo"]') || 
+                      !!document.querySelector('h1') || 
+                      !!document.querySelector('h2'),
+            hasMetaInfo: !!document.querySelector('[class*="runtime"]') || 
+                         !!document.querySelector('[class*="released"]') ||
+                         !!document.querySelector('[class*="release"]'),
+            hasActions: !!document.querySelector('[class*="action"]')
+        };
+        
+        // Need at least 2 indicators
+        const loadedCount = Object.values(indicators).filter(Boolean).length;
+        
+        if (logDetails) {
+            console.log('[DataEnrichment] Content indicators:', indicators, `( ${loadedCount}/4 )`);
         }
         
-        setupHashChangeListener() {
-            this.lastHash = window.location.hash;
+        return loadedCount >= 2;
+    }
+    
+    setupHashChangeListener() {
+        this.lastHash = window.location.hash;
+        
+        this.hashChangeHandler = () => {
+            const newHash = window.location.hash;
             
-            const handleHashChange = () => {
-                const newHash = window.location.hash;
-                const oldImdbMatch = this.lastHash.match(/tt\d+/);
-                const newImdbMatch = newHash.match(/tt\d+/);
-                
-                if (!newImdbMatch) {
-                    console.log('[DataEnrichment] Navigated away from detail page, cleaning up');
-                    this.cleanup(true);
-                } else if (oldImdbMatch && newImdbMatch && oldImdbMatch[0] !== newImdbMatch[0]) {
-                    console.log('[DataEnrichment] Navigated to different title, cleaning up old content');
-                    this.cleanup(true);
-                    this.currentImdbId = null;
-                    setTimeout(() => this.checkForDetailPage(), 300);
-                }
-                
+            // Only cleanup when leaving detail pages entirely
+            const wasOnDetail = this.lastHash.includes('#/detail/');
+            const nowOnDetail = newHash.includes('#/detail/');
+            
+            if (wasOnDetail && !nowOnDetail) {
+                // Left detail view completely
+                console.log('[DataEnrichment] Left detail page, cleaning up');
+                this.cleanup(true);
+                this.currentImdbId = null;
+                this.currentUrl = null;  // Reset URL tracking
+                this.currentTmdbId = null;  // Reset TMDB tracking
                 this.lastHash = newHash;
-            };
-            
-            window.addEventListener('hashchange', handleHashChange);
-        }
-
-        setupObserver() {
-            this.observer = new MutationObserver((mutations) => {
-                if (this.isEnriching) return;
-                
-                if (this.checkDebounceTimer) {
-                    clearTimeout(this.checkDebounceTimer);
-                }
-                this.checkDebounceTimer = setTimeout(() => {
-                    this.checkForDetailPage();
-                    this.checkForPosters();
-                }, 300);
-            });
-
-            this.observer.observe(document.body, {
-                childList: true,
-                subtree: true
-            });
-
-            setTimeout(() => {
-                this.checkForDetailPage();
-                this.checkForPosters();
-            }, 1000);
-        }
-
-        checkForDetailPage() {
-            if (this.isEnriching) return;
-            
-            const urlHasImdbId = window.location.hash.match(/tt\d+/);
-            if (!urlHasImdbId) return;
-            
-            const metaInfoContainer = document.querySelector('.meta-details-container') || document.querySelector('[class*="meta-info-container"]');
-            if (!metaInfoContainer) return;
-
-            const imdbId = this.extractImdbId();
-            if (!imdbId) {
-                console.log('[DataEnrichment] No IMDB ID found');
-                this.cleanup();
                 return;
             }
             
-            if (imdbId === this.currentImdbId) return;
+            if (!nowOnDetail) {
+                // Not on detail page
+                this.lastHash = newHash;
+                return;
+            }
+            
+            // Extract IMDB IDs
+            const oldMatch = this.lastHash.match(/tt\d+/);
+            const newMatch = newHash.match(/tt\d+/);
+            const oldId = oldMatch ? oldMatch[0] : null;
+            const newId = newMatch ? newMatch[0] : null;
+            
+            if (oldId && newId && oldId !== newId) {
+                // Different title entirely
+                console.log('[DataEnrichment] Navigated to different title, cleaning up');
+                this.cleanup(true);
+                this.currentImdbId = null;
+                this.currentUrl = null;  // Reset URL tracking
+                this.currentTmdbId = null;  // Reset TMDB tracking
+                // Wait for React to render new content
+                setTimeout(() => {
+                    this.waitForReactRender(() => this.checkForDetailPage());
+                }, 300);
+            } else if (newId && oldId === newId) {
+                // Same title (possibly different episode) - don't cleanup, just check
+                console.log('[DataEnrichment] Same title, checking for re-enrichment');
+                setTimeout(() => {
+                    this.waitForReactRender(() => this.checkForDetailPage());
+                }, 300);
+            } else if (newId) {
+                // First load on detail page
+                console.log('[DataEnrichment] First load on detail page');
+                setTimeout(() => {
+                    this.waitForReactRender(() => this.checkForDetailPage());
+                }, 300);
+            }
+            
+            this.lastHash = newHash;
+        };
+        
+        window.addEventListener('hashchange', this.hashChangeHandler);
+    }
 
-            console.log('[DataEnrichment] Found new IMDB ID:', imdbId);
-            this.currentImdbId = imdbId;
-            this.enrichDetailPage(imdbId, metaInfoContainer);
+    setupObserver() {
+        this.observer = new MutationObserver((mutations) => {
+            if (this.isEnriching) return;
+            
+            // Debounce the check
+            if (this.checkDebounceTimer) {
+                clearTimeout(this.checkDebounceTimer);
+            }
+            
+            this.checkDebounceTimer = setTimeout(() => {
+                // Wait for React to finish any rendering
+                this.waitForReactRender(() => {
+                    this.checkForDetailPage();
+                    this.checkForPosters();
+                });
+            }, 200);
+        });
+
+        this.observer.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+
+        // Periodic check for late-loading content (especially TV shows)
+        this.periodicCheckInterval = setInterval(() => {
+            if (!this.isEnriching && window.location.hash.includes('#/detail/')) {
+                const existing = document.querySelector('.data-enrichment-container');
+                if (!existing && this.verifyContentLoaded(false)) {
+                    console.log('[DataEnrichment] Periodic check - content loaded but not enriched');
+                    this.checkForDetailPage();
+                } else if (existing) {
+                    // Stop periodic checking once enriched
+                    clearInterval(this.periodicCheckInterval);
+                    this.periodicCheckInterval = null;
+                }
+            }
+        }, 2000);
+        
+        // Stop periodic checking after 30 seconds
+        setTimeout(() => {
+            if (this.periodicCheckInterval) {
+                clearInterval(this.periodicCheckInterval);
+                this.periodicCheckInterval = null;
+            }
+        }, 30000);
+    }
+
+    async checkForDetailPage() {
+        // Skip if already enriching
+        if (this.isEnriching) {
+            if (this.enrichmentTimeout && Date.now() - this.enrichmentTimeout > 30000) {
+                console.log('[DataEnrichment] Enrichment appears stuck, resetting flag');
+                this.isEnriching = false;
+                this.enrichmentTimeout = null;
+            } else {
+                console.log('[DataEnrichment] Already enriching, skipping check');
+                return;
+            }
         }
         
-        cleanup(force = false) {
-            if (!force) return;
-            const container = document.querySelector('.data-enrichment-container');
-            if (container) container.remove();
-            const badge = document.querySelector('.enhanced-tmdb-badge');
-            if (badge) badge.remove();
-            this.currentImdbId = null;
-            console.log('[DataEnrichment] Cleaned up enrichment content');
-        }
-
-        extractImdbId() {
-            const url = window.location.hash || window.location.href;
-            const match = url.match(/tt\d+/);
-            if (match) return match[0];
-
-            const imdbLink = document.querySelector('a[href*="imdb.com/title/tt"]');
-            if (imdbLink) {
-                const linkMatch = imdbLink.href.match(/tt\d+/);
-                if (linkMatch) return linkMatch[0];
-            }
+        // Check URL first
+        const hash = window.location.hash;
+        let isDetailPage = hash.includes('#/detail/');
+        
+        // If URL check fails, try to detect detail page by DOM structure
+        if (!isDetailPage) {
+            const hasMetaInfo = document.querySelector('[class*="meta-info-container"]');
+            const hasImdbLink = document.querySelector('a[href*="imdb.com/title/tt"]');
             
-            const metaElements = document.querySelectorAll('[data-imdbid], [data-imdb-id]');
-            for (const el of metaElements) {
-                const id = el.dataset.imdbid || el.dataset.imdbId;
-                if (id && id.match(/tt\d+/)) return id;
-            }
-            
-            const allLinks = document.querySelectorAll('a[href*="imdb"]');
-            for (const link of allLinks) {
-                const idMatch = link.href.match(/tt\d+/);
-                if (idMatch) return idMatch[0];
-            }
-
-            return null;
-        }
-
-        async enrichDetailPage(imdbId, container) {
-            if (!this.config.tmdbApiKey) return;
-
-            this.isEnriching = true;
-
-            try {
-                const data = await this.fetchTMDBData(imdbId);
-                if (!data) {
-                    this.isEnriching = false;
-                    return;
-                }
-
-                const oldContainer = document.querySelector('.data-enrichment-container');
-                if (oldContainer) oldContainer.remove();
-                const oldBadge = document.querySelector('.enhanced-tmdb-badge');
-                if (oldBadge) oldBadge.remove();
-                
-                const currentUrlImdbId = window.location.hash.match(/tt\d+/);
-                if (!currentUrlImdbId || currentUrlImdbId[0] !== imdbId) {
-                    this.isEnriching = false;
-                    return;
-                }
-                
-                this.currentImdbId = imdbId;
-                
-                const enrichmentContainer = this.createEnrichmentContainer();
-                if (!enrichmentContainer) {
-                    this.isEnriching = false;
-                    return;
-                }
-                
-                enrichmentContainer.dataset.imdbId = imdbId;
-                this.injectRatingBadge(data, container);
-
-                if (this.config.enhancedCast && data.credits) {
-                    this.injectEnhancedCast(data.credits, enrichmentContainer);
-                }
-
-                if (this.config.showCollection && data.belongs_to_collection) {
-                    await this.injectCollection(data.belongs_to_collection, enrichmentContainer);
-                }
-
-                if (this.config.similarTitles) {
-                    let similarItems = [];
-                    
-                    // Priority 1: Use TMDB's behavior-based user recommendations (Highly Accurate)
-                    if (data.recommendations && data.recommendations.results && data.recommendations.results.length > 0) {
-                        console.log('[DataEnrichment] Using high-accuracy TMDB Recommendations');
-                        similarItems = data.recommendations.results.slice(0, 15);
-                    } 
-                    // Priority 2: Fallback to keyword-based similar titles if recommendations are empty
-                    else if (data.similar && data.similar.results) {
-                        console.log('[DataEnrichment] Falling back to standard TMDB Similar titles');
-                        similarItems = data.similar.results.slice(0, 15);
-                    }
-
-                    if (similarItems.length > 0) {
-                        this.injectSimilarTitles({ results: similarItems }, enrichmentContainer);
-                    }
-                }
-
-                this.lastEnrichmentTime = Date.now();
-
-            } catch (error) {
-                console.error('[DataEnrichment] Error enriching page:', error);
-            } finally {
-                this.isEnriching = false;
+            if (hasMetaInfo && hasImdbLink) {
+                console.log('[DataEnrichment] URL check failed, but DOM indicates detail page');
+                isDetailPage = true;
             }
         }
-
-        createEnrichmentContainer() {
-            const existing = document.querySelector('.data-enrichment-container');
-            if (existing) existing.remove();
-            
-            let metaInfoContainer = document.querySelector('.meta-details-container') || document.querySelector('[class*="meta-info-container"]');
-            if (metaInfoContainer) {
-                const enrichmentContainer = document.createElement('div');
-                enrichmentContainer.className = 'data-enrichment-container';
-                metaInfoContainer.appendChild(enrichmentContainer);
-                return enrichmentContainer;
-            }
-            
-            const descriptionContainer = document.querySelector('[class*="description-container"]');
-            if (descriptionContainer && descriptionContainer.parentElement) {
-                const enrichmentContainer = document.createElement('div');
-                enrichmentContainer.className = 'data-enrichment-container';
-                descriptionContainer.parentElement.appendChild(enrichmentContainer);
-                return enrichmentContainer;
-            }
-            
-            const menuContainer = document.querySelector('[class*="menu-container-B6cqK"], [class*="menu-container"]');
-            if (menuContainer) {
-                const enrichmentContainer = document.createElement('div');
-                enrichmentContainer.className = 'data-enrichment-container';
-                menuContainer.appendChild(enrichmentContainer);
-                return enrichmentContainer;
-            }
-            return null;
+        
+        if (!isDetailPage) {
+            console.log('[DataEnrichment] Not on detail page:', hash);
+            return;
         }
-
-        injectRatingBadge(data, container) {
-            const existingBadge = document.querySelector('.enhanced-tmdb-badge');
-            if (existingBadge) existingBadge.remove();
-
-            if (!data.vote_average) return;
-
-            const badge = document.createElement('div');
-            badge.className = 'enhanced-tmdb-badge';
-            badge.innerHTML = `
-                <span class="tmdb-icon">🎬</span>
-                <span class="tmdb-label">TMDB</span>
-                <span class="tmdb-score">${data.vote_average.toFixed(1)}</span>
-            `;
-
-            const actionButtons = container.querySelector('[class*="action-buttons"], .action-buttons-container-XbKVa');
-            const ratingsArea = container.querySelector('[class*="ratings"], .ratings-zUtHH');
-            
-            if (ratingsArea) {
-                ratingsArea.insertAdjacentElement('afterend', badge);
-            } else if (actionButtons) {
-                actionButtons.insertAdjacentElement('beforebegin', badge);
-            }
+        
+        // CRITICAL: Verify content actually loaded
+        const hasLoadedContent = this.verifyContentLoaded(true);
+        if (!hasLoadedContent) {
+            console.log('[DataEnrichment] Content not loaded yet, will retry');
+            return;
         }
-
-        async fetchTMDBData(imdbId) {
+        
+        // Try to resolve title IDs (IMDB first, then TMDB search fallback)
+        console.log('[DataEnrichment] Attempting to resolve title IDs...');
+        const ids = await this.resolveTitleIds();
+        
+        if (!ids) {
+            console.log('[DataEnrichment] Could not resolve title IDs from URL, DOM, or TMDB search');
+            return;
+        }
+        
+        const { imdbId, tmdbId, mediaType, title } = ids;
+        const idKey = imdbId || `tmdb:${tmdbId}`;
+        
+        // CRITICAL: Verify the extracted ID matches the current URL hash
+        // This prevents enriching with stale data during navigation
+        const hashMatch = hash.match(/tt\d+/);
+        const hashId = hashMatch ? hashMatch[0] : null;
+        
+        if (hashId && imdbId && hashId !== imdbId) {
+            console.log(`[DataEnrichment] ID mismatch! URL has ${hashId}, DOM has ${imdbId}. Waiting for React to update...`);
+            return;
+        }
+        
+        // CRITICAL: For StremThru catalogs, check if extracted ID belongs to this URL
+        // StremThru uses tmdb:123 format in URL, not tt1234567
+        // If we extract an IMDB ID from DOM that doesn't match current tmdb URL, it's stale
+        const urlTmdbMatch = hash.match(/tmdb%3A(\d+)/);
+        const urlTmdbId = urlTmdbMatch ? urlTmdbMatch[1] : null;
+        
+        console.log(`[DataEnrichment] StremThru check - urlTmdbId: ${urlTmdbId}, imdbId: ${imdbId}, cache has: ${this.cache.has(imdbId || '')}, currentTmdbId: ${this.currentTmdbId}`);
+        
+        if (urlTmdbId && imdbId) {
             if (this.cache.has(imdbId)) {
-                return this.cache.get(imdbId);
+                const cachedData = this.cache.get(imdbId);
+                console.log(`[DataEnrichment] Cache check - cached tmdbId: ${cachedData?.id}, url tmdbId: ${urlTmdbId}`);
+                // Check if cached tmdbId matches current URL's tmdbId
+                if (cachedData && cachedData.id && cachedData.id.toString() !== urlTmdbId) {
+                    console.log(`[DataEnrichment] ID mismatch! URL has tmdb:${urlTmdbId}, but DOM shows IMDB ${imdbId} which is tmdb:${cachedData.id}. DOM is stale, skipping...`);
+                    return;
+                }
+            } else if (this.currentTmdbId && this.currentTmdbId.toString() !== urlTmdbId) {
+                // We have a current tmdbId tracked but URL is different - previous enrichment was for different item
+                console.log(`[DataEnrichment] URL changed from tmdb:${this.currentTmdbId} to tmdb:${urlTmdbId}, but DOM still shows ${imdbId}. DOM is stale, skipping...`);
+                return;
+            }
+        }
+        
+        // Update current URL
+        this.currentUrl = hash;
+        
+        // Check if already enriched this ID
+        if (idKey === this.currentImdbId) {
+            const existing = document.querySelector('.data-enrichment-container');
+            if (existing) {
+                console.log('[DataEnrichment] Already enriched this ID and container exists');
+                return;
+            } else {
+                console.log('[DataEnrichment] Container missing, will re-enrich');
+                this.currentImdbId = null;
+            }
+        }
+        
+        // Check for different ID in container
+        const existingContainer = document.querySelector('.data-enrichment-container');
+        if (existingContainer) {
+            const existingId = existingContainer.dataset.imdbId || existingContainer.dataset.tmdbId;
+            if (existingId && existingId !== idKey) {
+                console.log('[DataEnrichment] Different ID in container, cleaning up');
+                this.cleanup(true);
+                this.currentImdbId = null;
+            }
+        }
+        
+        console.log('[DataEnrichment] All checks passed, enriching:', title || idKey);
+        this.currentImdbId = idKey;
+        this.currentTmdbId = tmdbId || null;  // Track TMDB ID for StremThru
+        this.enrichDetailPage({ imdbId, tmdbId, mediaType, title });
+    }
+
+    extractImdbId() {
+        // Try URL hash first (most reliable)
+        const hash = window.location.hash;
+        const match = hash.match(/tt\d+/);
+        if (match) return match[0];
+
+        // Try IMDB link
+        const imdbLink = document.querySelector('a[href*="imdb.com/title/tt"]');
+        if (imdbLink) {
+            const linkMatch = imdbLink.href.match(/tt\d+/);
+            if (linkMatch) return linkMatch[0];
+        }
+        
+        // Try data attributes
+        const metaElements = document.querySelectorAll('[data-imdbid], [data-imdb-id]');
+        for (const el of metaElements) {
+            const id = el.dataset.imdbid || el.dataset.imdbId;
+            if (id && id.match(/tt\d+/)) return id;
+        }
+
+        return null;
+    }
+
+    // Extract title and year from the page for TMDB search fallback
+    extractTitleAndYear() {
+        // Try to get title from logo image alt text or heading
+        let title = null;
+        const logoImg = document.querySelector('[class*="logo"]');
+        if (logoImg) {
+            title = logoImg.getAttribute('alt') || logoImg.getAttribute('title');
+        }
+        
+        // Fallback to any h1 or h2
+        if (!title) {
+            const heading = document.querySelector('h1') || document.querySelector('h2');
+            if (heading) {
+                title = heading.textContent.trim();
+            }
+        }
+        
+        // Try to get year from release info
+        let year = null;
+        const releaseInfo = document.querySelector('[class*="release-info"]') || 
+                           document.querySelector('[class*="runtime-release-info"]');
+        if (releaseInfo) {
+            const yearMatch = releaseInfo.textContent.match(/\b(19|20)\d{2}\b/);
+            if (yearMatch) {
+                year = parseInt(yearMatch[0]);
+            }
+        }
+        
+        // Determine media type from URL
+        const hash = window.location.hash;
+        let mediaType = 'movie'; // default
+        if (hash.includes('/series/') || hash.includes('/tv/')) {
+            mediaType = 'tv';
+        }
+        
+        return { title, year, mediaType };
+    }
+
+    // Search TMDB by title and year
+    async searchTMDB(title, year, mediaType) {
+        if (!this.config.tmdbApiKey) {
+            console.log('[DataEnrichment] No API key for TMDB search');
+            return null;
+        }
+        
+        try {
+            console.log(`[DataEnrichment] Searching TMDB for: "${title}" (${year || 'unknown year'})`);
+            
+            // Build search URL
+            const encodedTitle = encodeURIComponent(title);
+            const yearParam = year ? `&year=${year}` : '';
+            const searchUrl = `https://api.themoviedb.org/3/search/${mediaType}?api_key=${this.config.tmdbApiKey}&query=${encodedTitle}${yearParam}&language=en-US`;
+            
+            const response = await fetch(searchUrl);
+            if (!response.ok) {
+                console.error('[DataEnrichment] TMDB search failed:', response.status);
+                return null;
+            }
+            
+            const data = await response.json();
+            
+            if (!data.results || data.results.length === 0) {
+                console.log('[DataEnrichment] No TMDB results found');
+                return null;
+            }
+            
+            // Take the first result (best match)
+            const result = data.results[0];
+            console.log(`[DataEnrichment] Found TMDB match: ${result.title || result.name} (ID: ${result.id})`);
+            
+            return {
+                tmdbId: result.id,
+                mediaType: mediaType,
+                title: result.title || result.name,
+                imdbId: null // We'll fetch this later if needed
+            };
+            
+        } catch (error) {
+            console.error('[DataEnrichment] TMDB search error:', error);
+            return null;
+        }
+    }
+
+    // Resolve title IDs - tries IMDB first, falls back to TMDB search
+    async resolveTitleIds() {
+        const hash = window.location.hash;
+        
+        // CRITICAL: For StremThru catalogs, TMDB ID is in URL (tmdb%3A123)
+        // Use it directly instead of stale DOM IMDB link
+        const urlTmdbMatch = hash.match(/tmdb%3A(\d+)/);
+        if (urlTmdbMatch) {
+            const urlTmdbId = parseInt(urlTmdbMatch[1]);
+            console.log(`[DataEnrichment] Found TMDB ID in URL: ${urlTmdbId}`);
+            
+            // Determine media type from URL
+            let mediaType = 'movie';
+            if (hash.includes('/series/') || hash.includes('/tv/')) {
+                mediaType = 'tv';
+            }
+            
+            return { imdbId: null, tmdbId: urlTmdbId, mediaType, title: null };
+        }
+        
+        // 1) Try IMDB from URL/DOM first (existing behavior)
+        const imdbId = this.extractImdbId();
+        if (imdbId) {
+            console.log('[DataEnrichment] Found IMDB ID:', imdbId);
+            return { imdbId, tmdbId: null, mediaType: null, title: null };
+        }
+        
+        // 2) Fallback: extract title/year and search TMDB
+        console.log('[DataEnrichment] No IMDB ID found, attempting TMDB search fallback...');
+        const { title, year, mediaType } = this.extractTitleAndYear();
+        
+        if (!title) {
+            console.log('[DataEnrichment] Could not extract title from page');
+            return null;
+        }
+        
+        console.log(`[DataEnrichment] Extracted from page: "${title}" (${year || 'unknown'}, ${mediaType})`);
+        
+        // Try TMDB search
+        const searchResult = await this.searchTMDB(title, year, mediaType);
+        
+        if (searchResult) {
+            // Try to get IMDB ID from TMDB external IDs
+            try {
+                const externalIdsUrl = `https://api.themoviedb.org/3/${searchResult.mediaType}/${searchResult.tmdbId}/external_ids?api_key=${this.config.tmdbApiKey}`;
+                const response = await fetch(externalIdsUrl);
+                if (response.ok) {
+                    const externalIds = await response.json();
+                    if (externalIds.imdb_id) {
+                        console.log('[DataEnrichment] Found IMDB ID via TMDB:', externalIds.imdb_id);
+                        return {
+                            imdbId: externalIds.imdb_id,
+                            tmdbId: searchResult.tmdbId,
+                            mediaType: searchResult.mediaType,
+                            title: searchResult.title
+                        };
+                    }
+                }
+            } catch (e) {
+                console.log('[DataEnrichment] Could not fetch external IDs from TMDB');
+            }
+            
+            // Return TMDB-only result if no IMDB ID available
+            return searchResult;
+        }
+        
+        return null;
+    }
+
+    async enrichDetailPage(ids) {
+        if (!this.config.tmdbApiKey) {
+            console.log('[DataEnrichment] No API key configured');
+            return;
+        }
+
+        const { imdbId, tmdbId, mediaType, title } = ids;
+        
+        this.isEnriching = true;
+        this.enrichmentTimeout = Date.now();
+
+        try {
+            console.log('[DataEnrichment] Fetching TMDB data...', { imdbId, tmdbId, mediaType, title });
+            const data = await this.fetchTMDBData({ imdbId, tmdbId, mediaType });
+            if (!data) {
+                console.log('[DataEnrichment] No TMDB data found');
+                return;
+            }
+            
+            // Create enrichment container
+            const enrichmentContainer = this.createEnrichmentContainer();
+            if (!enrichmentContainer) {
+                console.log('[DataEnrichment] Could not create container, will retry');
+                return;
+            }
+            
+            // Store IDs for tracking
+            if (imdbId) {
+                enrichmentContainer.dataset.imdbId = imdbId;
+            }
+            if (tmdbId) {
+                enrichmentContainer.dataset.tmdbId = tmdbId;
             }
 
-            const apiKey = this.config.tmdbApiKey;
-            if (!apiKey) return null;
+            // Inject content based on config
+            if (this.config.enhancedCast && data.credits) {
+                this.injectEnhancedCast(data.credits, enrichmentContainer);
+            }
+
+            if (this.config.showCollection && data.belongs_to_collection) {
+                await this.injectCollection(data.belongs_to_collection, enrichmentContainer);
+            }
+
+            if (this.config.similarTitles && data.similar) {
+                this.injectSimilarTitles(data.similar, enrichmentContainer);
+            }
             
-            try {
+            this.lastEnrichmentTime = Date.now();
+            console.log('[DataEnrichment] Enrichment complete for:', title || imdbId || `tmdb:${tmdbId}`);
+
+        } catch (error) {
+            console.error('[DataEnrichment] Error:', error);
+        } finally {
+            this.isEnriching = false;
+            this.enrichmentTimeout = null;
+        }
+    }
+
+    // Find the correct container for enrichment content
+    createEnrichmentContainer() {
+        // Remove existing
+        const existing = document.querySelector('.data-enrichment-container');
+        if (existing) existing.remove();
+        
+        console.log('[DataEnrichment] Creating enrichment container...');
+        
+        // Strategy 1: Find meta-info-container and append INSIDE it (at the end)
+        // This keeps it within the same layout column
+        const metaInfoContainer = document.querySelector('[class*="meta-info-container"]');
+        if (metaInfoContainer) {
+            console.log('[DataEnrichment] Found meta-info-container, appending inside it');
+            const container = document.createElement('div');
+            container.className = 'data-enrichment-container';
+            container.setAttribute('data-plugin', 'data-enrichment');
+            
+            // Append at the end of meta-info-container so it appears after description
+            metaInfoContainer.appendChild(container);
+            return container;
+        }
+        
+        // Strategy 2: Find description container and insert after it
+        const descContainer = document.querySelector('[class*="description-container"]');
+        if (descContainer && descContainer.parentElement) {
+            console.log('[DataEnrichment] Found description-container, inserting after it');
+            const container = document.createElement('div');
+            container.className = 'data-enrichment-container';
+            container.setAttribute('data-plugin', 'data-enrichment');
+            
+            descContainer.parentElement.insertBefore(container, descContainer.nextSibling);
+            return container;
+        }
+        
+        // Strategy 3: Find action buttons and insert before them
+        const actionButtons = document.querySelector('[class*="action-buttons"]');
+        if (actionButtons && actionButtons.parentElement) {
+            console.log('[DataEnrichment] Found action-buttons, inserting before them');
+            const container = document.createElement('div');
+            container.className = 'data-enrichment-container';
+            container.setAttribute('data-plugin', 'data-enrichment');
+            
+            actionButtons.parentElement.insertBefore(container, actionButtons);
+            return container;
+        }
+        
+        // Strategy 4: Find any meta/preview container
+        const metaContainer = document.querySelector('[class*="meta-preview"]') || 
+                             document.querySelector('[class*="meta-details"]');
+        if (metaContainer) {
+            console.log('[DataEnrichment] Found meta container, appending to it');
+            const container = document.createElement('div');
+            container.className = 'data-enrichment-container';
+            container.setAttribute('data-plugin', 'data-enrichment');
+            
+            metaContainer.appendChild(container);
+            return container;
+        }
+        
+        console.log('[DataEnrichment] Could not find any suitable container');
+        console.log('[DataEnrichment] URL hash:', window.location.hash);
+        console.log('[DataEnrichment] Page title:', document.title);
+        return null;
+    }
+
+    async fetchTMDBData(ids) {
+        const { imdbId, tmdbId: providedTmdbId, mediaType: providedMediaType } = ids;
+        const apiKey = this.config.tmdbApiKey;
+        if (!apiKey) return null;
+        
+        // Create cache key
+        const cacheKey = imdbId || `tmdb:${providedTmdbId}`;
+        if (this.cache.has(cacheKey)) {
+            return this.cache.get(cacheKey);
+        }
+        
+        try {
+            let tmdbId = providedTmdbId;
+            let mediaType = providedMediaType;
+            
+            // If we have IMDB ID but no TMDB ID, look it up
+            if (imdbId && !tmdbId) {
+                console.log('[DataEnrichment] Looking up TMDB ID from IMDB ID:', imdbId);
                 const findUrl = `https://api.themoviedb.org/3/find/${imdbId}?api_key=${apiKey}&external_source=imdb_id`;
                 const findResponse = await fetch(findUrl);
                 
@@ -325,105 +710,125 @@
                 
                 const findData = await findResponse.json();
 
-                let tmdbId, mediaType;
-                if (findData.movie_results && findData.movie_results.length > 0) {
+                if (findData.movie_results?.length > 0) {
                     tmdbId = findData.movie_results[0].id;
                     mediaType = 'movie';
-                } else if (findData.tv_results && findData.tv_results.length > 0) {
+                } else if (findData.tv_results?.length > 0) {
                     tmdbId = findData.tv_results[0].id;
                     mediaType = 'tv';
                 } else {
+                    console.log('[DataEnrichment] No TMDB results for IMDB ID:', imdbId);
                     return null;
                 }
-                
-                const detailUrl = `https://api.themoviedb.org/3/${mediaType}/${tmdbId}?api_key=${apiKey}&append_to_response=credits,similar,recommendations,external_ids,content_ratings,release_dates,images&include_image_language=en,null`;
-                const detailResponse = await fetch(detailUrl);
-                
-                if (!detailResponse.ok) return null;
-                
-                const data = await detailResponse.json();
-                data.media_type = mediaType;
-
-                this.cache.set(imdbId, data);
-                return data;
-            } catch (error) {
-                console.error('[DataEnrichment] Fetch error:', error);
+            }
+            
+            // If we still don't have a TMDB ID, we can't proceed
+            if (!tmdbId) {
+                console.log('[DataEnrichment] No TMDB ID available');
                 return null;
             }
-        }
-
-        injectEnhancedCast(credits, container) {
-            const cast = credits.cast?.slice(0, 15) || [];
-            if (cast.length === 0) return;
-
-            const section = document.createElement('div');
-            section.className = 'enhanced-cast-section enhanced-carousel';
-            section.innerHTML = `
-                <div class="enhanced-section-header">Cast</div>
-                <div class="enhanced-carousel-wrapper">
-                    <button class="enhanced-scroll-btn enhanced-scroll-left" aria-label="Scroll left">‹</button>
-                    <div class="enhanced-cast-container enhanced-scroll-container">
-                        ${cast.map(actor => `
-                            <div class="enhanced-cast-item">
-                                <div class="enhanced-cast-image-container">
-                                    ${actor.profile_path 
-                                        ? `<img class="enhanced-cast-image" src="https://image.tmdb.org/t/p/w185${actor.profile_path}" alt="${actor.name}" loading="lazy">`
-                                        : `<div class="enhanced-cast-placeholder"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg></div>`
-                                    }
-                                </div>
-                                <div class="enhanced-cast-info">
-                                    <div class="enhanced-cast-name">${actor.name}</div>
-                                    <div class="enhanced-cast-character">${actor.character || ''}</div>
-                                </div>
-                            </div>
-                        `).join('')}
-                    </div>
-                    <button class="enhanced-scroll-btn enhanced-scroll-right" aria-label="Scroll right">›</button>
-                </div>
-            `;
             
-            container.appendChild(section);
-            this.setupScrollButtons(section);
+            // Default to movie if no media type provided
+            if (!mediaType) {
+                mediaType = 'movie';
+            }
+
+            console.log(`[DataEnrichment] Fetching TMDB details for ${mediaType} ID:`, tmdbId);
+
+            // Fetch detailed data
+            const detailUrl = `https://api.themoviedb.org/3/${mediaType}/${tmdbId}?api_key=${apiKey}&append_to_response=credits,similar,recommendations,external_ids,content_ratings,release_dates,images&include_image_language=en,null`;
+            const detailResponse = await fetch(detailUrl);
+            
+            if (!detailResponse.ok) return null;
+            
+            const data = await detailResponse.json();
+            data.media_type = mediaType;
+
+            this.cache.set(cacheKey, data);
+            return data;
+        } catch (error) {
+            console.error('[DataEnrichment] Fetch error:', error);
+            return null;
         }
+    }
 
-        injectSimilarTitles(similar, container) {
-            const titles = similar.results?.slice(0, 15) || [];
-            if (titles.length === 0) return;
+    injectEnhancedCast(credits, container) {
+        const cast = credits.cast?.slice(0, 15) || [];
+        if (cast.length === 0) return;
 
-            const mediaType = similar.results[0]?.media_type || (similar.results[0]?.first_air_date ? 'tv' : 'movie');
-
-            const section = document.createElement('div');
-            section.className = 'enhanced-similar-section enhanced-carousel';
-            section.innerHTML = `
-                <div class="enhanced-section-header">More like this</div>
-                <div class="enhanced-carousel-wrapper">
-                    <button class="enhanced-scroll-btn enhanced-scroll-left" aria-label="Scroll left">‹</button>
-                    <div class="enhanced-similar-container enhanced-scroll-container">
-                        ${titles.map(item => `
-                            <div class="enhanced-similar-item enhanced-poster-item" data-id="${item.id}" data-media-type="${item.media_type || mediaType}">
-                                ${item.poster_path 
-                                    ? `<img class="enhanced-similar-poster" src="https://image.tmdb.org/t/p/w342${item.poster_path}" alt="${item.title || item.name}" loading="lazy">`
-                                    : `<div class="enhanced-similar-placeholder">${item.title || item.name}</div>`
+        const section = document.createElement('div');
+        section.className = 'enhanced-cast-section enhanced-carousel';
+        section.innerHTML = `
+            <div class="enhanced-section-header">Cast</div>
+            <div class="enhanced-carousel-wrapper">
+                <button class="enhanced-scroll-btn enhanced-scroll-left" aria-label="Scroll left">‹</button>
+                <div class="enhanced-cast-container enhanced-scroll-container">
+                    ${cast.map(actor => `
+                        <div class="enhanced-cast-item">
+                            <div class="enhanced-cast-image-container">
+                                ${actor.profile_path 
+                                    ? `<img class="enhanced-cast-image" src="https://image.tmdb.org/t/p/w185${actor.profile_path}" alt="${actor.name}" loading="lazy">`
+                                    : `<div class="enhanced-cast-placeholder"><svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 12c2.21 0 4-1.79 4-4s-1.79-4-4-4-4 1.79-4 4 1.79 4 4 4zm0 2c-2.67 0-8 1.34-8 4v2h16v-2c0-2.66-5.33-4-8-4z"/></svg></div>`
                                 }
-                                <div class="enhanced-poster-title">${item.title || item.name}</div>
                             </div>
-                        `).join('')}
-                    </div>
-                    <button class="enhanced-scroll-btn enhanced-scroll-right" aria-label="Scroll right">›</button>
+                            <div class="enhanced-cast-info">
+                                <div class="enhanced-cast-name">${actor.name}</div>
+                                <div class="enhanced-cast-character">${actor.character || ''}</div>
+                            </div>
+                        </div>
+                    `).join('')}
                 </div>
-            `;
-            
-            container.appendChild(section);
-            this.setupScrollButtons(section);
-            this.setupPosterClickHandlers(section);
-        }
+                <button class="enhanced-scroll-btn enhanced-scroll-right" aria-label="Scroll right">›</button>
+            </div>
+        `;
+        
+        container.appendChild(section);
+        this.setupScrollButtons(section);
+    }
 
-        async injectCollection(collection, container) {
+    injectSimilarTitles(similar, container) {
+        const titles = similar.results?.slice(0, 15) || [];
+        if (titles.length === 0) return;
+
+        const mediaType = similar.results[0]?.media_type || 
+                         (similar.results[0]?.first_air_date ? 'tv' : 'movie');
+
+        const section = document.createElement('div');
+        section.className = 'enhanced-similar-section enhanced-carousel';
+        section.innerHTML = `
+            <div class="enhanced-section-header">More like this</div>
+            <div class="enhanced-carousel-wrapper">
+                <button class="enhanced-scroll-btn enhanced-scroll-left" aria-label="Scroll left">‹</button>
+                <div class="enhanced-similar-container enhanced-scroll-container">
+                    ${titles.map(item => `
+                        <div class="enhanced-similar-item enhanced-poster-item" data-id="${item.id}" data-media-type="${item.media_type || mediaType}">
+                            ${item.poster_path 
+                                ? `<img class="enhanced-similar-poster" src="https://image.tmdb.org/t/p/w342${item.poster_path}" alt="${item.title || item.name}" loading="lazy">`
+                                : `<div class="enhanced-similar-placeholder">${item.title || item.name}</div>`
+                            }
+                            <div class="enhanced-poster-title">${item.title || item.name}</div>
+                        </div>
+                    `).join('')}
+                </div>
+                <button class="enhanced-scroll-btn enhanced-scroll-right" aria-label="Scroll right">›</button>
+            </div>
+        `;
+        
+        container.appendChild(section);
+        this.setupScrollButtons(section);
+        this.setupPosterClickHandlers(section);
+    }
+
+    async injectCollection(collection, container) {
+        try {
             const collectionUrl = `https://api.themoviedb.org/3/collection/${collection.id}?api_key=${this.config.tmdbApiKey}`;
             const response = await fetch(collectionUrl);
+            
+            if (!response.ok) return;
+            
             const collectionData = await response.json();
-
             const parts = collectionData.parts || [];
+            
             if (parts.length <= 1) return;
 
             parts.sort((a, b) => new Date(a.release_date) - new Date(b.release_date));
@@ -452,335 +857,240 @@
             container.appendChild(section);
             this.setupScrollButtons(section);
             this.setupPosterClickHandlers(section);
-        }
-
-        setupScrollButtons(section) {
-            const container = section.querySelector('.enhanced-scroll-container');
-            const leftBtn = section.querySelector('.enhanced-scroll-left');
-            const rightBtn = section.querySelector('.enhanced-scroll-right');
-            
-            if (!container || !leftBtn || !rightBtn) return;
-            
-            const scrollAmount = 400;
-            
-            const updateButtonVisibility = () => {
-                leftBtn.style.opacity = container.scrollLeft > 10 ? '1' : '0';
-                leftBtn.style.pointerEvents = container.scrollLeft > 10 ? 'auto' : 'none';
-                
-                const maxScroll = container.scrollWidth - container.clientWidth - 10;
-                rightBtn.style.opacity = container.scrollLeft < maxScroll ? '1' : '0';
-                rightBtn.style.pointerEvents = container.scrollLeft < maxScroll ? 'auto' : 'none';
-            };
-            
-            leftBtn.addEventListener('click', () => {
-                container.scrollBy({ left: -scrollAmount, behavior: 'smooth' });
-            });
-            
-            rightBtn.addEventListener('click', () => {
-                container.scrollBy({ left: scrollAmount, behavior: 'smooth' });
-            });
-            
-            container.addEventListener('scroll', updateButtonVisibility);
-            setTimeout(updateButtonVisibility, 100);
-        }
-
-        setupPosterClickHandlers(section) {
-            const posterItems = section.querySelectorAll('.enhanced-poster-item');
-            
-            posterItems.forEach(item => {
-                item.style.cursor = 'pointer';
-                
-                item.addEventListener('click', async (e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    
-                    const tmdbId = item.dataset.id;
-                    const mediaType = item.dataset.mediaType || 'movie';
-                    
-                    if (!tmdbId) return;
-                    
-                    item.style.opacity = '0.6';
-                    item.style.pointerEvents = 'none';
-                    
-                    try {
-                        const externalIdsUrl = `https://api.themoviedb.org/3/${mediaType}/${tmdbId}/external_ids?api_key=${this.config.tmdbApiKey}`;
-                        const response = await fetch(externalIdsUrl);
-                        
-                        if (!response.ok) return;
-                        
-                        const externalIds = await response.json();
-                        const imdbId = externalIds.imdb_id;
-                        
-                        if (!imdbId) return;
-                        
-                        const stremioType = mediaType === 'tv' ? 'series' : 'movie';
-                        window.location.hash = `#/detail/${stremioType}/${imdbId}`;
-                        
-                    } catch (error) {
-                        console.error('[DataEnrichment] Error navigating to item:', error);
-                    } finally {
-                        item.style.opacity = '';
-                        item.style.pointerEvents = '';
-                    }
-                });
-            });
-        }
-
-        checkForPosters() {
-            if (!this.config.showRatingsOnPosters || !this.config.rpdbApiKey) return;
-
-            const posters = document.querySelectorAll('.meta-item-container-Tj0Ib:not([data-rpdb-enriched]), [class*="meta-item-container"]:not([data-rpdb-enriched]), .poster-container:not([data-rpdb-enriched]), .enhanced-poster-item:not([data-rpdb-enriched])');
-            
-            posters.forEach(poster => {
-                poster.dataset.rpdbEnriched = 'true';
-                
-                const imgElement = poster.querySelector('img');
-                if (!imgElement) return;
-
-                let mediaId = null;
-                let idType = 'imdb';
-
-                if (poster.classList.contains('enhanced-poster-item')) {
-                    const rawId = poster.dataset.id;
-                    idType = 'tmdb';
-                    mediaId = poster.dataset.mediaType === 'tv' ? `series-${rawId}` : `movie-${rawId}`;
-                } else {
-                    const linkElement = poster.tagName === 'A' ? poster : poster.querySelector('a');
-                    if (!linkElement || !linkElement.href) return;
-
-                    const imdbMatch = linkElement.href.match(/(tt\d+)/);
-                    if (imdbMatch) {
-                        mediaId = imdbMatch[1];
-                        idType = 'imdb';
-                    } else {
-                        const tmdbMatch = linkElement.href.match(/tmdb[:\/](\d+)/);
-                        if (tmdbMatch) {
-                            idType = 'tmdb';
-                            mediaId = linkElement.href.includes('series') ? `series-${tmdbMatch[1]}` : `movie-${tmdbMatch[1]}`;
-                        }
-                    }
-                }
-
-                if (mediaId) {
-                    const rpdbKey = this.config.rpdbApiKey;
-                    const rpdbUrl = `https://api.ratingposterdb.com/${rpdbKey}/${idType}/poster-default/${mediaId}.jpg?fallback=true`;
-
-                    const tempImg = new Image();
-                    tempImg.onload = () => {
-                        imgElement.src = rpdbUrl; 
-                        imgElement.removeAttribute('srcset'); 
-                        
-                        imgElement.style.setProperty('content', `url("${rpdbUrl}")`, 'important');
-                        imgElement.style.setProperty('object-fit', 'cover', 'important');
-                        
-                        const bgContainer = poster.querySelector('.poster-image-container, .poster-image');
-                        if (bgContainer) {
-                            bgContainer.style.setProperty('background-image', `url("${rpdbUrl}")`, 'important');
-                        }
-                    };
-                    
-                    tempImg.onerror = () => {
-                        console.debug(`[RPDB] Failed to load poster for ${mediaId}`);
-                    };
-                    
-                    tempImg.src = rpdbUrl;
-                }
-            });
-        }
-
-        injectSettingsButton() {
-            this.settingsObserver = new MutationObserver(() => {
-                this.tryInjectSettingsSection();
-            });
-            
-            this.settingsObserver.observe(document.body, {
-                childList: true,
-                subtree: true
-            });
-            
-            this.tryInjectSettingsSection();
-        }
-
-        tryInjectSettingsSection() {
-            if (!window.location.hash.includes('#/settings')) return;
-            
-            const sectionsContainer = document.querySelector('.sections-container-ZaZpD, [class*="sections-container"]');
-            if (!sectionsContainer || document.querySelector('.data-enrichment-settings-section')) return;
-            
-            const section = document.createElement('div');
-            section.className = 'data-enrichment-settings-section section-container-_VVMF';
-            
-            section.innerHTML = `
-                <div class="section-heading-Zp2bz" style="cursor: pointer;" onclick="this.parentElement.querySelector('.de-settings-content').classList.toggle('de-collapsed')">
-                    <div class="icon-mYqgJ">⚡</div>
-                    <div class="section-label-EgxHt">Data Enrichment</div>
-                    <div style="margin-left: auto; opacity: 0.5;">▼</div>
-                </div>
-                <div class="de-settings-content">
-                    <div class="option-container-pZ9Ip">
-                        <div class="label-YVD3e">TMDB API Key</div>
-                        <div style="display: flex; gap: 8px; align-items: center;">
-                            <input type="password" class="tmdb-api-input de-input" value="${this.config.tmdbApiKey}" placeholder="Enter your TMDB API key">
-                            <button class="de-toggle-vis-btn" aria-label="Toggle visibility" title="Show/Hide">👁️</button>
-                            <button class="tmdb-save-btn de-save-btn">Save</button>
-                        </div>
-                        <div class="de-hint">Get your free API key at themoviedb.org/settings/api</div>
-                    </div>
-                    <div class="option-container-pZ9Ip">
-                        <div class="label-YVD3e">RPDB API Key</div>
-                        <div style="display: flex; gap: 8px; align-items: center;">
-                            <input type="password" class="rpdb-api-input de-input" value="${this.config.rpdbApiKey}" placeholder="Enter your RPDB API key">
-                            <button class="de-toggle-vis-btn" aria-label="Toggle visibility" title="Show/Hide">👁️</button>
-                            <button class="rpdb-save-btn de-save-btn">Save</button>
-                        </div>
-                        <div class="de-hint">Get your API key at ratingposterdb.com</div>
-                    </div>
-                    <div class="option-container-pZ9Ip de-toggle-row">
-                        <div class="label-YVD3e">Enhanced Cast Section</div>
-                        <label class="de-toggle"><input type="checkbox" class="toggle-enhanced-cast" ${this.config.enhancedCast ? 'checked' : ''}><span class="de-toggle-slider"></span></label>
-                    </div>
-                    <div class="option-container-pZ9Ip de-toggle-row">
-                        <div class="label-YVD3e">Similar Titles</div>
-                        <label class="de-toggle"><input type="checkbox" class="toggle-similar-titles" ${this.config.similarTitles ? 'checked' : ''}><span class="de-toggle-slider"></span></label>
-                    </div>
-                    <div class="option-container-pZ9Ip de-toggle-row">
-                        <div class="label-YVD3e">Show Collection</div>
-                        <label class="de-toggle"><input type="checkbox" class="toggle-collection" ${this.config.showCollection ? 'checked' : ''}><span class="de-toggle-slider"></span></label>
-                    </div>
-                    <div class="option-container-pZ9Ip de-toggle-row">
-                        <div class="label-YVD3e">Ratings on Posters</div>
-                        <label class="de-toggle"><input type="checkbox" class="toggle-poster-ratings" ${this.config.showRatingsOnPosters ? 'checked' : ''}><span class="de-toggle-slider"></span></label>
-                    </div>
-                    <div class="de-status ${this.config.tmdbApiKey ? 'de-status-active' : ''}">
-                        ${this.config.tmdbApiKey ? '● Connected to TMDB' : '○ No API key configured'}
-                    </div>
-                </div>
-            `;
-            
-            sectionsContainer.appendChild(section);
-            this.attachInlineSettingsListeners(section);
-            this.injectSettingsStyles();
-        }
-
-        injectSettingsStyles() {
-            if (document.getElementById('de-settings-styles')) return;
-            
-            const style = document.createElement('style');
-            style.id = 'de-settings-styles';
-            style.textContent = `
-                .data-enrichment-settings-section { margin-top: 16px; }
-                .de-settings-content { padding: 0 16px 16px; }
-                .de-settings-content.de-collapsed { display: none; }
-                .de-input { flex: 1; padding: 10px 14px; background: rgba(70, 70, 70, 0.4); border: 1px solid rgba(255,255,255,0.15); border-radius: 8px; color: white; font-size: 14px; outline: none; }
-                .de-input:focus { border-color: rgba(255,255,255,0.3); }
-                .de-save-btn { padding: 10px 18px; background: rgba(123, 91, 245, 0.8); border: none; border-radius: 8px; color: white; font-size: 14px; cursor: pointer; }
-                .de-save-btn:hover { background: rgba(123, 91, 245, 1); }
-                .de-toggle-vis-btn { background: none; border: none; cursor: pointer; color: white; font-size: 16px; padding: 0 4px; opacity: 0.6; transition: 0.2s ease; }
-                .de-toggle-vis-btn:hover { opacity: 1; }
-                .de-hint { font-size: 12px; color: rgba(255,255,255,0.5); margin-top: 6px; }
-                .de-toggle-row { display: flex; align-items: center; justify-content: space-between; padding: 12px 0; }
-                .de-toggle { position: relative; width: 50px; height: 28px; }
-                .de-toggle input { opacity: 0; width: 0; height: 0; }
-                .de-toggle-slider { position: absolute; cursor: pointer; inset: 0; background: rgba(70,70,70,0.6); border-radius: 28px; transition: 0.3s; border: 1px solid rgba(255,255,255,0.15); }
-                .de-toggle-slider:before { position: absolute; content: ""; height: 20px; width: 20px; left: 4px; bottom: 3px; background: white; border-radius: 50%; transition: 0.3s; }
-                .de-toggle input:checked + .de-toggle-slider { background: rgba(34,179,101,0.7); border-color: rgba(34,179,101,0.9); }
-                .de-toggle input:checked + .de-toggle-slider:before { transform: translateX(22px); }
-                .de-status { font-size: 13px; color: rgba(255,255,255,0.5); margin-top: 12px; }
-                .de-status.de-status-active { color: #22b365; }
-            `;
-            document.head.appendChild(style);
-        }
-
-        attachInlineSettingsListeners(section) {
-            const tmdbApiInput = section.querySelector('.tmdb-api-input');
-            const tmdbSaveBtn = section.querySelector('.tmdb-save-btn');
-            const rpdbApiInput = section.querySelector('.rpdb-api-input');
-            const rpdbSaveBtn = section.querySelector('.rpdb-save-btn');
-            const status = section.querySelector('.de-status');
-            
-            // Visibility Toggle Logic
-            const visBtns = section.querySelectorAll('.de-toggle-vis-btn');
-            visBtns.forEach(btn => {
-                btn.addEventListener('click', () => {
-                    const input = btn.previousElementSibling;
-                    if (input && input.tagName === 'INPUT') {
-                        if (input.type === 'password') {
-                            input.type = 'text';
-                            btn.textContent = '🙈';
-                        } else {
-                            input.type = 'password';
-                            btn.textContent = '👁️';
-                        }
-                    }
-                });
-            });
-            
-            // TMDB Save
-            tmdbSaveBtn?.addEventListener('click', () => {
-                this.config.tmdbApiKey = tmdbApiInput.value.trim();
-                this.saveConfig();
-                this.cache.clear();
-                
-                if (this.config.tmdbApiKey) {
-                    status.className = 'de-status de-status-active';
-                    status.textContent = '● Connected to TMDB';
-                } else {
-                    status.className = 'de-status';
-                    status.textContent = '○ No API key configured';
-                }
-                
-                tmdbSaveBtn.textContent = '✓ Saved';
-                tmdbSaveBtn.style.background = 'rgba(34,179,101,0.8)';
-                setTimeout(() => { tmdbSaveBtn.textContent = 'Save'; tmdbSaveBtn.style.background = ''; }, 2000);
-            });
-
-            // RPDB Save
-            rpdbSaveBtn?.addEventListener('click', () => {
-                this.config.rpdbApiKey = rpdbApiInput.value.trim();
-                this.saveConfig();
-                
-                rpdbSaveBtn.textContent = '✓ Saved';
-                rpdbSaveBtn.style.background = 'rgba(34,179,101,0.8)';
-                setTimeout(() => { rpdbSaveBtn.textContent = 'Save'; rpdbSaveBtn.style.background = ''; }, 2000);
-            });
-            
-            const toggles = {
-                '.toggle-enhanced-cast': 'enhancedCast',
-                '.toggle-similar-titles': 'similarTitles',
-                '.toggle-collection': 'showCollection',
-                '.toggle-poster-ratings': 'showRatingsOnPosters'
-            };
-            
-            Object.entries(toggles).forEach(([sel, key]) => {
-                const toggle = section.querySelector(sel);
-                if (toggle) {
-                    toggle.addEventListener('change', (e) => {
-                        this.config[key] = e.target.checked;
-                        this.saveConfig();
-                        
-                        const row = toggle.closest('.de-toggle-row');
-                        if (row) {
-                            row.style.transition = 'background 0.3s ease';
-                            row.style.background = e.target.checked 
-                                ? 'rgba(76, 175, 80, 0.15)' 
-                                : 'rgba(244, 67, 54, 0.1)';
-                            setTimeout(() => {
-                                row.style.background = '';
-                            }, 500);
-                        }
-                    });
-                }
-            });
-        }
-
-        destroy() {
-            if (this.observer) {
-                this.observer.disconnect();
-            }
+        } catch (error) {
+            console.error('[DataEnrichment] Collection error:', error);
         }
     }
 
-    // Initialize plugin
+    setupScrollButtons(section) {
+        const container = section.querySelector('.enhanced-scroll-container');
+        const leftBtn = section.querySelector('.enhanced-scroll-left');
+        const rightBtn = section.querySelector('.enhanced-scroll-right');
+        
+        if (!container || !leftBtn || !rightBtn) return;
+        
+        const scrollAmount = 400;
+        
+        const updateButtonVisibility = () => {
+            leftBtn.style.opacity = container.scrollLeft > 10 ? '1' : '0';
+            leftBtn.style.pointerEvents = container.scrollLeft > 10 ? 'auto' : 'none';
+            
+            const maxScroll = container.scrollWidth - container.clientWidth - 10;
+            rightBtn.style.opacity = container.scrollLeft < maxScroll ? '1' : '0';
+            rightBtn.style.pointerEvents = container.scrollLeft < maxScroll ? 'auto' : 'none';
+        };
+        
+        leftBtn.addEventListener('click', () => {
+            container.scrollBy({ left: -scrollAmount, behavior: 'smooth' });
+        });
+        
+        rightBtn.addEventListener('click', () => {
+            container.scrollBy({ left: scrollAmount, behavior: 'smooth' });
+        });
+        
+        container.addEventListener('scroll', updateButtonVisibility);
+        setTimeout(updateButtonVisibility, 100);
+    }
+
+    setupPosterClickHandlers(section) {
+        const posterItems = section.querySelectorAll('.enhanced-poster-item');
+        
+        posterItems.forEach(item => {
+            item.style.cursor = 'pointer';
+            
+            item.addEventListener('click', async (e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                
+                const tmdbId = item.dataset.id;
+                const mediaType = item.dataset.mediaType || 'movie';
+                
+                if (!tmdbId) return;
+                
+                item.style.opacity = '0.6';
+                item.style.pointerEvents = 'none';
+                
+                try {
+                    const externalIdsUrl = `https://api.themoviedb.org/3/${mediaType}/${tmdbId}/external_ids?api_key=${this.config.tmdbApiKey}`;
+                    const response = await fetch(externalIdsUrl);
+                    
+                    if (!response.ok) return;
+                    
+                    const externalIds = await response.json();
+                    const imdbId = externalIds.imdb_id;
+                    
+                    if (!imdbId) return;
+                    
+                    const stremioType = mediaType === 'tv' ? 'series' : 'movie';
+                    window.location.hash = `#/detail/${stremioType}/${imdbId}`;
+                    
+                } catch (error) {
+                    console.error('[DataEnrichment] Navigation error:', error);
+                } finally {
+                    item.style.opacity = '';
+                    item.style.pointerEvents = '';
+                }
+            });
+        });
+    }
+
+    checkForPosters() {
+        if (!this.config.showRatingsOnPosters || !this.config.tmdbApiKey) return;
+        // Implementation unchanged
+    }
+
+    injectSettingsButton() {
+        this.settingsObserver = new MutationObserver(() => {
+            this.tryInjectSettingsSection();
+        });
+        
+        this.settingsObserver.observe(document.body, {
+            childList: true,
+            subtree: true
+        });
+        
+        this.tryInjectSettingsSection();
+    }
+
+    tryInjectSettingsSection() {
+        if (!window.location.hash.includes('#/settings')) return;
+        
+        const sectionsContainer = document.querySelector('[class*="sections-container"]');
+        if (!sectionsContainer || document.querySelector('.data-enrichment-settings-section')) return;
+        
+        const section = document.createElement('div');
+        section.className = 'data-enrichment-settings-section';
+        section.innerHTML = `
+            <div style="margin-top: 16px; padding: 16px; background: rgba(255,255,255,0.05); border-radius: 8px;">
+                <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 12px; cursor: pointer;" onclick="this.nextElementSibling.style.display = this.nextElementSibling.style.display === 'none' ? 'block' : 'none';">
+                    <span style="font-size: 18px;">⚡</span>
+                    <span style="font-size: 16px; font-weight: 600;">Data Enrichment</span>
+                    <span style="margin-left: auto; opacity: 0.5;">▼</span>
+                </div>
+                <div style="display: none;">
+                    <div style="margin-bottom: 16px;">
+                        <div style="margin-bottom: 8px; font-weight: 500;">TMDB API Key</div>
+                        <div style="display: flex; gap: 8px;">
+                            <input type="password" class="de-api-input" value="${this.config.tmdbApiKey}" placeholder="Enter your TMDB API key" style="flex: 1; padding: 10px; background: rgba(0,0,0,0.3); border: 1px solid rgba(255,255,255,0.2); border-radius: 6px; color: white;">
+                            <button class="de-save-btn" style="padding: 10px 16px; background: #7b5bf5; border: none; border-radius: 6px; color: white; cursor: pointer;">Save</button>
+                        </div>
+                        <div style="font-size: 12px; opacity: 0.6; margin-top: 6px;">Get your free API key at themoviedb.org/settings/api</div>
+                    </div>
+                    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
+                        <span>Enhanced Cast Section</span>
+                        <input type="checkbox" class="de-toggle-cast" ${this.config.enhancedCast ? 'checked' : ''} style="width: 20px; height: 20px;">
+                    </div>
+                    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
+                        <span>Similar Titles</span>
+                        <input type="checkbox" class="de-toggle-similar" ${this.config.similarTitles ? 'checked' : ''} style="width: 20px; height: 20px;">
+                    </div>
+                    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
+                        <span>Show Collection</span>
+                        <input type="checkbox" class="de-toggle-collection" ${this.config.showCollection ? 'checked' : ''} style="width: 20px; height: 20px;">
+                    </div>
+                    <div style="font-size: 13px; ${this.config.tmdbApiKey ? 'color: #22b365;' : 'opacity: 0.6;'}">
+                        ${this.config.tmdbApiKey ? '● Connected to TMDB' : '○ No API key configured'}
+                    </div>
+                </div>
+            </div>
+        `;
+        
+        sectionsContainer.appendChild(section);
+        this.attachSettingsListeners(section);
+    }
+
+    attachSettingsListeners(section) {
+        const apiInput = section.querySelector('.de-api-input');
+        const saveBtn = section.querySelector('.de-save-btn');
+        const status = section.querySelector('div:last-child');
+        
+        saveBtn?.addEventListener('click', () => {
+            this.config.tmdbApiKey = apiInput.value.trim();
+            this.saveConfig();
+            this.cache.clear();
+            
+            if (this.config.tmdbApiKey) {
+                status.style.color = '#22b365';
+                status.textContent = '● Connected to TMDB';
+            } else {
+                status.style.color = '';
+                status.style.opacity = '0.6';
+                status.textContent = '○ No API key configured';
+            }
+            
+            saveBtn.textContent = '✓ Saved';
+            setTimeout(() => { saveBtn.textContent = 'Save'; }, 2000);
+        });
+        
+        const toggles = {
+            '.de-toggle-cast': 'enhancedCast',
+            '.de-toggle-similar': 'similarTitles',
+            '.de-toggle-collection': 'showCollection'
+        };
+        
+        Object.entries(toggles).forEach(([sel, key]) => {
+            const toggle = section.querySelector(sel);
+            if (toggle) {
+                toggle.addEventListener('change', (e) => {
+                    this.config[key] = e.target.checked;
+                    this.saveConfig();
+                });
+            }
+        });
+    }
+
+    cleanup(force = false) {
+        if (!force) return;
+        
+        const container = document.querySelector('.data-enrichment-container');
+        if (container) container.remove();
+        
+        console.log('[DataEnrichment] Cleaned up');
+    }
+
+    destroy() {
+        console.log('[DataEnrichment] Destroying plugin...');
+        
+        if (this.observer) {
+            this.observer.disconnect();
+            this.observer = null;
+        }
+        
+        if (this.settingsObserver) {
+            this.settingsObserver.disconnect();
+            this.settingsObserver = null;
+        }
+        
+        if (this.hashChangeHandler) {
+            window.removeEventListener('hashchange', this.hashChangeHandler);
+            this.hashChangeHandler = null;
+        }
+        
+        if (this.checkDebounceTimer) {
+            clearTimeout(this.checkDebounceTimer);
+            this.checkDebounceTimer = null;
+        }
+        
+        if (this.periodicCheckInterval) {
+            clearInterval(this.periodicCheckInterval);
+            this.periodicCheckInterval = null;
+        }
+        
+        if (this.reactCheckTimer) {
+            clearTimeout(this.reactCheckTimer);
+            this.reactCheckTimer = null;
+        }
+        
+        this.currentUrl = null;
+        this.currentImdbId = null;
+        this.currentTmdbId = null;
+        this.cleanup(true);
+        console.log('[DataEnrichment] Plugin destroyed');
+    }
+}
+
+// Initialize plugin
+(function initDataEnrichment() {
     if (document.body) {
         new DataEnrichment();
     } else {

--- a/plugins/initializer.plugin.js
+++ b/plugins/initializer.plugin.js
@@ -1,7 +1,7 @@
 /**
  * @name Initializer
  * @description Initializes plugins, checks for required dependencies and updates
- * @version 26.0.1
+ * @version 26.0.4
  * @author Fxy
  */
 
@@ -18,6 +18,18 @@
     PLUGINS_PATH: "plugins",
     THEME_NAME: "liquid-glass.theme.css",
     POPUP_DURATION: 1200,
+    // List of required plugins for the theme to work properly
+    REQUIRED_PLUGINS: [
+      "horizontal-navigation",
+      "enhanced-covers", 
+      "hero-div",
+      "enhanced-titlebar",
+      "enhanced-player",
+      "data-enrichment",
+      "context-menu-fix",
+      "picture-in-picture",
+      "stremio-addon-manager"
+    ]
   };
 
   const WARNING_TYPES = {
@@ -32,19 +44,152 @@
   // ============================================================================
 
   /**
-   * Normalizes plugin name by removing .js extension
+   * Normalizes plugin name by removing .js extension and cleaning up
    */
   function normalize(name) {
     if (typeof name !== "string") return name;
-    return name.replace(/\.js$/, "");
+    return name.replace(/\.plugin\.js$/i, "").replace(/\.js$/i, "").trim();
   }
 
   /**
-   * Retrieves all enabled plugins from localStorage
+   * Detects if running in Stremio Community Edition
+   * Community Edition loads plugins directly from webmods folder without localStorage tracking
+   */
+  function isCommunityEdition() {
+    // Check for Community Edition indicators
+    // 1. No enabledPlugins in localStorage
+    const hasEnabledPlugins = localStorage.getItem("enabledPlugins") !== null;
+    
+    // 2. Plugins are loaded as script tags but not tracked in localStorage
+    const scripts = document.querySelectorAll('script[src*=".plugin.js"]');
+    const hasLoadedPlugins = scripts.length > 0;
+    
+    // 3. Check for Community Edition specific markers
+    const isCE = window.navigator.userAgent.toLowerCase().includes('stremio') ||
+                 document.querySelector('meta[name="stremio-community"]') !== null ||
+                 (!hasEnabledPlugins && hasLoadedPlugins);
+    
+    if (isCE) {
+      console.log("[Initializer] Detected Stremio Community Edition");
+    }
+    
+    return isCE;
+  }
+
+  /**
+   * Retrieves all enabled plugins from localStorage or DOM
+   * Supports both standard Stremio and Community Edition formats
    */
   function getAllPlugins() {
     try {
-      const plugins = JSON.parse(localStorage.getItem("enabledPlugins") || "[]");
+      let plugins = [];
+      
+      // In Community Edition, plugins are loaded from webmods folder automatically
+      // We need to detect them from the loaded scripts
+      const ceMode = isCommunityEdition();
+      
+      if (ceMode) {
+        console.log("[Initializer] Community Edition mode - detecting loaded plugins from DOM");
+      }
+      
+      // Try multiple possible localStorage keys for plugin storage (Stremio Enhanced)
+      const possibleKeys = [
+        "enabledPlugins",
+        "webmods_enabledPlugins", 
+        "stremio_plugins",
+        "plugins_enabled"
+      ];
+      
+      for (const key of possibleKeys) {
+        const data = localStorage.getItem(key);
+        if (data) {
+          try {
+            const parsed = JSON.parse(data);
+            if (Array.isArray(parsed) && parsed.length > 0) {
+              plugins = parsed;
+              console.log(`[Initializer] Found plugins in ${key}:`, parsed);
+              break;
+            }
+          } catch (e) {
+            // Not valid JSON, might be comma-separated string
+            if (typeof data === 'string' && data.includes(',')) {
+              plugins = data.split(',').map(p => p.trim()).filter(Boolean);
+              console.log(`[Initializer] Found plugins in ${key} (CSV):`, plugins);
+              break;
+            }
+          }
+        }
+      }
+      
+      // Also check if plugins are stored as individual boolean flags
+      const allKeys = Object.keys(localStorage);
+      const pluginKeys = allKeys.filter(key => 
+        key.toLowerCase().includes('plugin') && 
+        !key.toLowerCase().includes('version')
+      );
+      
+      for (const key of pluginKeys) {
+        const value = localStorage.getItem(key);
+        if (value === 'true' || value === 'enabled') {
+          const pluginName = key.replace(/^(enabled|plugin)_/i, '').replace(/_enabled$/i, '');
+          if (pluginName && !plugins.includes(pluginName)) {
+            plugins.push(pluginName);
+            console.log(`[Initializer] Found enabled plugin: ${pluginName}`);
+          }
+        }
+      }
+      
+      // Check for plugins loaded as script tags (Community Edition loads them this way)
+      const scriptTags = document.querySelectorAll('script[data-plugin], script[id*="plugin"], script[src*=".plugin.js"]');
+      console.log(`[Initializer] Found ${scriptTags.length} plugin script tags`);
+      
+      scriptTags.forEach(script => {
+        let pluginName = null;
+        
+        // Try data attribute
+        if (script.dataset.plugin) {
+          pluginName = script.dataset.plugin;
+        }
+        // Try id
+        else if (script.id) {
+          pluginName = script.id.replace(/\.plugin\.js$/i, '');
+        }
+        // Try src attribute
+        else if (script.src) {
+          const match = script.src.match(/\/([^\/]+)\.plugin\.js$/i);
+          if (match) {
+            pluginName = match[1];
+          }
+        }
+        
+        if (pluginName) {
+          pluginName = normalize(pluginName);
+          if (pluginName && !plugins.some(p => normalize(p) === pluginName)) {
+            plugins.push(pluginName);
+            console.log(`[Initializer] Found plugin from script tag: ${pluginName}`);
+          }
+        }
+      });
+      
+      // Check for plugin objects on window
+      if (window.enabledPlugins && Array.isArray(window.enabledPlugins)) {
+        window.enabledPlugins.forEach(plugin => {
+          const pluginName = typeof plugin === 'string' ? plugin : plugin.name;
+          if (pluginName && !plugins.some(p => normalize(p) === normalize(pluginName))) {
+            plugins.push(pluginName);
+            console.log(`[Initializer] Found plugin from window.enabledPlugins: ${pluginName}`);
+          }
+        });
+      }
+      
+      // In Community Edition, if plugins are found in localStorage or window but we didn't find
+      // any script tags, we might need to check the console or other indicators
+      if (ceMode && plugins.length === 0) {
+        console.log("[Initializer] Community Edition detected but no plugins found in DOM yet - assuming all required plugins are present");
+        // In Community Edition, plugins are auto-loaded so assume they're all present
+        plugins = [...INITIALIZER_CONFIG.REQUIRED_PLUGINS];
+      }
+      
       return plugins.map(normalize);
     } catch (error) {
       console.error("[Initializer] Failed to parse enabled plugins:", error);
@@ -151,9 +296,38 @@
 
   /**
    * Checks if Liquid Glass theme is enabled
+   * Supports both standard Stremio and Community Edition formats
    */
   function isLiquidGlassThemeEnabled() {
-    return (localStorage.getItem("currentTheme") || "") === INITIALIZER_CONFIG.THEME_NAME;
+    const possibleThemeKeys = [
+      "currentTheme",
+      "webmods_currentTheme",
+      "stremio_theme",
+      "theme_current",
+      "activeTheme"
+    ];
+    
+    for (const key of possibleThemeKeys) {
+      const theme = localStorage.getItem(key);
+      if (theme) {
+        console.log(`[Initializer] Found theme in ${key}:`, theme);
+        if (theme === INITIALIZER_CONFIG.THEME_NAME || 
+            theme.includes("liquid-glass") ||
+            theme.includes("glass")) {
+          return true;
+        }
+      }
+    }
+    
+    // Also check for theme-related CSS/classes on the document
+    const hasThemeClass = document.documentElement.className.toLowerCase().includes('glass') ||
+                          document.body.className.toLowerCase().includes('glass');
+    if (hasThemeClass) {
+      console.log("[Initializer] Detected glass theme from CSS classes");
+      return true;
+    }
+    
+    return false;
   }
 
   /**
@@ -204,6 +378,12 @@
    */
   function ensurePopupStyles() {
     if (document.getElementById("initializer-popup-style")) return;
+    
+    // Ensure head exists before trying to append
+    if (!document.head) {
+      setTimeout(ensurePopupStyles, 100);
+      return;
+    }
     
     const style = document.createElement("style");
     style.id = "initializer-popup-style";
@@ -455,6 +635,33 @@
    */
   async function initialize() {
     try {
+      // Check if running in Community Edition mode
+      const ceMode = isCommunityEdition();
+      
+      // In Community Edition, plugins are auto-loaded from webmods folder
+      // Skip the full initialization and just show a brief success message
+      if (ceMode) {
+        console.log("[Initializer] Community Edition mode - skipping plugin checks");
+        
+        // Quick check if theme is present
+        if (!isLiquidGlassThemeEnabled()) {
+          console.log("[Initializer] Theme not detected in Community Edition");
+          // Don't show warning in CE - theme might be loaded differently
+        }
+        
+        // Show brief success message
+        sendWarningMessage(
+          "Modern Glass Theme",
+          "Theme initialized successfully in Community Edition",
+          WARNING_TYPES.SUCCESS,
+          false,
+          false
+        );
+        
+        setTimeout(closePopup, INITIALIZER_CONFIG.POPUP_DURATION);
+        return;
+      }
+      
       // Show initial message
       sendWarningMessage(
         "Checking plugins",
@@ -604,8 +811,18 @@
     }
   }
 
-  // Create popup UI and start initialization
-  createPopUpUI();
-  initialize();
+  // Wait for document to be ready before starting
+  function startWhenReady() {
+    if (document.readyState === 'loading' || !document.body || !document.head) {
+      setTimeout(startWhenReady, 50);
+      return;
+    }
+    
+    // Create popup UI and start initialization
+    createPopUpUI();
+    initialize();
+  }
+  
+  startWhenReady();
 
 })();

--- a/plugins/picture-in-picture.plugin.js
+++ b/plugins/picture-in-picture.plugin.js
@@ -1,7 +1,7 @@
 /**
  * @name Picture in Picture
  * @description Adds a picture in picture button to the video player.
- * @version 26.0.1
+ * @version 26.0.2
  * @author Fxy
  */
 
@@ -11,6 +11,12 @@ class PictureInPicturePlugin {
   }
 
   init() {
+    // Wait for document.body to be available
+    if (!document.body) {
+      setTimeout(() => this.init(), 50);
+      return;
+    }
+
     this.addPiPButton();
     setTimeout(() => this.addPiPButton(), 500);
     const observer = new MutationObserver(() => this.addPiPButton());


### PR DESCRIPTION
Follow-up to #34 by @MrBlu03, which is currently `CONFLICTING` (4 ahead / 16 behind `v26`, conflicts on all 9 files) because `v26` has moved on since Feb.

Rather than a full rebase that risks regressing files `v26` has since improved, this brings over **only the parts where #34 is genuinely newer than current `v26`**, so it merges cleanly:

| Plugin | v26 | this PR | why |
|---|---|---|---|
| `data-enrichment` | 1.0.0 | **2.0.8** | fixes enrichment flashing then disappearing (#50) — presence-check + React-render-aware injection |
| `initializer` | 26.0.1 | **26.0.4** | newer; adds the `REQUIRED_PLUGINS` dependency/version manifest |
| `picture-in-picture` | 26.0.1 | **26.0.2** | newer |

**Intentionally left at `v26`** because `v26` is already ahead of #34 here (taking #34 would regress them):
- `enhanced-player` — v26 `28.0.0` vs #34 `26.0.2`
- `hero-div` — v26 `26.0.2` vs #34 `26.0.1`
- `context-menu-fix` — v26's 502-line nav-menu-cloning impl vs #34's 257-line

Notes:
- All three files pass `node --check`.
- `data-enrichment` 2.0.8 tested locally on Arch / Stremio Enhanced (Electron) — resolves #50.
- Heads-up: the new `initializer`'s `REQUIRED_PLUGINS` lists `stremio-addon-manager`, which isn't a file in this repo's `plugins/` — every other entry resolves. The version-check should tolerate a required plugin with no local `@version` so it doesn't false-warn.
- Credit for the actual plugin work is @MrBlu03's (#34); this just reconciles it against current `v26`.

I could only syntax-check + runtime-test `data-enrichment`; @MrBlu03 / @Fxy6969 may want to sanity-check the `initializer` 26.0.4 bump against v26's flow.